### PR TITLE
feat: Enhance request to bypass risk control (Bilibili)

### DIFF
--- a/extractor/build.gradle
+++ b/extractor/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.8.1'
     implementation 'commons-codec:commons-codec:1.16.0'
     implementation "org.json:json:20231013"
+    implementation 'org.cache2k:cache2k-api:2.6.1.Final'
+    implementation 'org.cache2k:cache2k-core:2.6.1.Final'
 
 
     // do not upgrade to 1.7.14, since in 1.7.14 Rhino uses the `SourceVersion` class, which is not

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Request.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/downloader/Request.java
@@ -48,7 +48,7 @@ public class Request {
         if (headers != null) {
             actualHeaders.putAll(headers);
         }
-        if (automaticLocalizationHeader && localization != null) {
+        if (automaticLocalizationHeader && localization != null && !actualHeaders.containsKey("Accept-Language")) {
             actualHeaders.putAll(headersFromLocalization(localization));
         }
 

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliService.java
@@ -3,15 +3,14 @@ package org.schabi.newpipe.extractor.services.bilibili;
 import com.grack.nanojson.JsonObject;
 import com.grack.nanojson.JsonParser;
 import com.grack.nanojson.JsonParserException;
-import org.apache.commons.lang3.StringUtils;
 import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.StreamingService;
 import org.schabi.newpipe.extractor.bulletComments.BulletCommentsExtractor;
 import org.schabi.newpipe.extractor.channel.ChannelExtractor;
 import org.schabi.newpipe.extractor.channel.ChannelTabExtractor;
 import org.schabi.newpipe.extractor.comments.CommentsExtractor;
+import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
-import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.kiosk.KioskList;
 import org.schabi.newpipe.extractor.linkhandler.LinkHandler;
@@ -41,21 +40,43 @@ import org.schabi.newpipe.extractor.services.bilibili.linkHandler.BilibiliStream
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
 import org.schabi.newpipe.extractor.subscription.SubscriptionExtractor;
 import org.schabi.newpipe.extractor.suggestion.SuggestionExtractor;
+import org.schabi.newpipe.extractor.utils.Utils;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 import static org.schabi.newpipe.extractor.NewPipe.getDownloader;
 import static org.schabi.newpipe.extractor.StreamingService.ServiceInfo.MediaCapability.*;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.bytesToHex;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 public class BilibiliService extends StreamingService {
     private final WatchDataCache watchDataCache;
+    private static LinkedHashMap<String, String> defaultLatestCookies = null;
 
-    public static String FREE_VIDEO_BASE_URL = "https://api.bilibili.com/x/player/playurl";
+    public static final String WWW_REFERER = "https://www.bilibili.com/";
+    public static final String SPACE_REFERER = "https://space.bilibili.com/";
+    public static final String LIVE_REFERER = "https://live.bilibili.com/";
+
+    public static String FREE_VIDEO_BASE_URL = "https://api.bilibili.com/x/player/wbi/playurl";
     public static String PAID_VIDEO_BASE_URL = "https://api.bilibili.com/pgc/player/web/playurl";
     public static String LIVE_BASE_URL = "live.bilibili.com";
     public static String QUERY_VIDEO_BULLET_COMMENTS_URL = "https://api.bilibili.com/x/v1/dm/list.so?oid=";
@@ -69,7 +90,7 @@ public class BilibiliService extends StreamingService {
     public static String GET_SEASON_ARCHIVES_ARCHIVE_BASE_URL = "https://api.bilibili.com/x/polymer/web-space/seasons_archives_list";
     public static String GET_SUGGESTION_URL = "https://s.search.bilibili.com/main/suggest?term=";
     public static String GET_RELATED_URL = "https://api.bilibili.com/x/web-interface/archive/related?bvid=";
-    public static String COMMENT_REPLIES_URL = "https://api.bilibili.com/x/v2/reply/reply?type=1&pn=1&ps=20&oid=";
+    public static String COMMENT_REPLIES_URL = "https://api.bilibili.com/x/v2/reply/reply?type=1&ps=10&pn=1&web_location=333.788&oid=";
     public static String GET_SUBTITLE_META_URL = "https://api.bilibili.com/x/player/wbi/v2";
     public static String QUERY_USER_VIDEOS_WEB_API_URL = "https://api.bilibili.com/x/space/wbi/arc/search";
     public static String QUERY_USER_VIDEOS_CLIENT_API_URL = "https://app.bilibili.com/x/v2/space/archive/cursor";
@@ -77,37 +98,192 @@ public class BilibiliService extends StreamingService {
     public static String GET_PARTITION_URL = "https://api.bilibili.com/x/player/pagelist?bvid=";
     public static String FETCH_COOKIE_URL = "https://api.bilibili.com/x/frontend/finger/spi";
     public static String FETCH_COMMENTS_URL = "https://api.bilibili.com/x/v2/reply/wbi/main";
-    public static String FETCH_TAGS_URL = "https://api.bilibili.com/x/tag/archive/tags?bvid=";
+    public static String FETCH_TAGS_URL = "https://api.bilibili.com/x/web-interface/view/detail/tag?bvid=";
     public final static String FETCH_RECOMMENDED_LIVES_URL = "https://api.live.bilibili.com/xlive/web-interface/v1/second/getUserRecommend?page_size=30&platform=web";
     public static String VIDEOSHOT_API_URL = "https://api.bilibili.com/x/player/videoshot?index=1&bvid=";
+    public final static String FETCH_TICKET_URL = "https://api.bilibili.com/bapis/bilibili.api.ticket.v1.Ticket/GenWebTicket";
 
+    private static String mapToCookieHeader(LinkedHashMap<String, String> cookies) {
+        if (cookies == null || cookies.isEmpty()) {
+            return "";
+        }
+        return cookies.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining("; ")); // Join with "; " for readability
+    }
 
-    static public Map<String, List<String>> getHeaders() {
-        final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Cookie", Collections.singletonList("buvid3=1DCAF0E0-E1BF-FA62-7963-5503227CF1B124755infoc;"));
-        headers.put("User-Agent", Collections.singletonList(DeviceForger.requireRandomDevice().getUserAgent()));
-        headers.put("Referer", Collections.singletonList("https://www.bilibili.com"));
+    /**
+     * Generate a HMAC-SHA256 hash of the given message string using the given key
+     * string.
+     *
+     * @param key     The key string to use for the HMAC-SHA256 hash.
+     * @param message The message string to hash.
+     * @return The HMAC-SHA256 hash of the given message string using the given key
+     * string.
+     */
+    private static String hmacSha256(String key, String message) {
+        Mac mac;
+        try {
+            mac = Mac.getInstance("HmacSHA256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        try {
+            mac.init(secretKeySpec);
+        } catch (InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+        byte[] hash = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
+        return bytesToHex(hash);
+    }
+
+    /**
+     * Get a Bilibili web ticket for the given CSRF token.
+     *
+     * @param csrf The CSRF token to use for the web ticket, can be {@code null} or
+     *             empty.
+     * @see <a href="https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/misc/sign/bili_ticket.md">BiliTicket</a>
+     */
+    private static Map.Entry<String, Long> getBiliTicket(String csrf, LinkedHashMap<String, String> cookies) throws IOException, JsonParserException {
+        // params
+        long ts = Instant.now().getEpochSecond();
+        String hexSign = hmacSha256("XgwSnGZ1p", "ts" + ts);
+        String url = FETCH_TICKET_URL + '?' +
+                "key_id=ec02" + '&' +
+                "hexsign=" + hexSign + '&' +
+                "context[ts]=" + ts + '&' +
+                "csrf=" + (csrf == null ? "" : csrf);
+        LinkedHashMap<String, List<String>> headers = getUserAgentHeaders(WWW_REFERER);
+        headers.put("Cookie", Collections.singletonList(mapToCookieHeader(cookies)));
+        Response response;
+        try {
+            response = getDownloader().post(url, headers, null);
+        } catch (ReCaptchaException e) {
+            throw new IOException(e);
+        }
+        JsonObject data = Objects.requireNonNull(JsonParser.object().from(response.responseBody()).getObject("data"), "data");
+        String ticket = Objects.requireNonNull(data.getString("ticket"), "ticket");
+        long createdAt = data.getLong("created_at");
+        if (createdAt <= 0) {
+            throw new IllegalArgumentException("created_at: " + createdAt);
+        }
+        long ttl = data.getLong("ttl");
+        if (ttl <= 0) {
+            throw new IllegalArgumentException("ttl: " + ttl);
+        }
+        long expires = createdAt + ttl;
+        return new AbstractMap.SimpleEntry<>(ticket, expires);
+    }
+
+    /**
+     * @see <a href="https://github.com/SocialSisterYi/bilibili-API-collect/issues/933">_uuid</a>
+     */
+    private static String getFpUuid() {
+        final String[] DIGIT_MAP = {
+                "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "10"
+        };
+
+        // Get the last 5 digits of the current timestamp
+        long t = System.currentTimeMillis() % 100_000;
+
+        // Generate 32 random bytes
+        byte[] index = new byte[32];
+        ThreadLocalRandom.current().nextBytes(index);
+
+        // Build the main part of the UUID string
+        StringBuilder result = new StringBuilder(64);
+        List<Integer> hyphenIndices = Arrays.asList(9, 13, 17, 21);
+
+        for (int ii = 0; ii < index.length; ii++) {
+            if (hyphenIndices.contains(ii)) {
+                result.append('-');
+            }
+            // Use the lower 4 bits of the random byte as an index into DIGIT_MAP
+            result.append(DIGIT_MAP[index[ii] & 0x0f]);
+        }
+
+        // Append the formatted timestamp and the suffix
+        result.append(String.format("%05d", t));
+        result.append("infoc");
+
+        return result.toString();
+    }
+
+    static public LinkedHashMap<String, String> getDefaultCookies() throws IOException {
+        if (defaultLatestCookies == null || Long.parseLong(defaultLatestCookies.get("bili_ticket_expires")) <= Instant.now().getEpochSecond()) {
+            Response response;
+            try {
+                response = getDownloader().get(FETCH_COOKIE_URL, getUserAgentHeaders(WWW_REFERER));
+            } catch (ReCaptchaException e) {
+                throw new IOException(e);
+            }
+            JsonObject data;
+            try {
+                data = Objects.requireNonNull(JsonParser.object().from(response.responseBody()).getObject("data"), "data");
+            } catch (JsonParserException e) {
+                throw new IOException(e);
+            }
+            LinkedHashMap<String, String> cookies = new LinkedHashMap<>();
+            cookies.put("buvid3", Objects.requireNonNull(data.getString("b_3"), "b_3"));
+            cookies.put("b_nut", String.valueOf(
+                    ZonedDateTime.parse(Objects.requireNonNull(response.getHeader("date"), "date"), DateTimeFormatter.RFC_1123_DATE_TIME).toEpochSecond()
+            ));
+            byte[] randomLsidBytes = new byte[32];
+            ThreadLocalRandom.current().nextBytes(randomLsidBytes);
+            String randomLsid = String.format("%s_%X", bytesToHex(randomLsidBytes).toUpperCase(Locale.ROOT), System.currentTimeMillis());
+            cookies.put("b_lsid", randomLsid);
+            cookies.put("_uuid", getFpUuid());
+            cookies.put("buvid4", Objects.requireNonNull(data.getString("b_4"), "b_4"));
+
+            try {
+                Map.Entry<String, Long> biliTicket = getBiliTicket("", cookies);
+                cookies.put("bili_ticket", biliTicket.getKey());
+                cookies.put("bili_ticket_expires", String.valueOf(biliTicket.getValue()));
+            } catch (JsonParserException e) {
+                throw new RuntimeException(e);
+            }
+
+            byte[] randomBuvidFp = new byte[16];
+            ThreadLocalRandom.current().nextBytes(randomBuvidFp);
+            cookies.put("buvid_fp", bytesToHex(randomBuvidFp));
+
+            defaultLatestCookies = cookies;
+        }
+        return defaultLatestCookies;
+    }
+
+    static public LinkedHashMap<String, List<String>> getHeaders(String originalUrl) throws IOException {
+        LinkedHashMap<String, List<String>> headers = getUserAgentHeaders(originalUrl);
+        String cookie = mapToCookieHeader(getDefaultCookies());
+        headers.put("Cookie", Collections.singletonList(cookie));
         return headers;
     }
 
-    static public Map<String, List<String>> getUserAgentHeaders() {
-        final Map<String, List<String>> headers = new HashMap<>();
+    static public LinkedHashMap<String, List<String>> getUserAgentHeaders(String originalUrl) throws MalformedURLException {
+        final LinkedHashMap<String, List<String>> headers = new LinkedHashMap<>();
         headers.put("User-Agent", Collections.singletonList(DeviceForger.requireRandomDevice().getUserAgent()));
-        headers.put("Referer", Collections.singletonList("https://www.bilibili.com"));
+        if (originalUrl != null) {
+            String referer = "https://" + Utils.stringToURL(originalUrl).getHost() + "/";
+            if (!Arrays.asList(WWW_REFERER, SPACE_REFERER, LIVE_REFERER).contains(referer)) {
+                referer = WWW_REFERER;
+            }
+            headers.put("Referer", Collections.singletonList(referer));
+        }
+        headers.put("Accept-Language", Collections.singletonList("zh-CN,zh;q=0.9"));
         return headers;
     }
 
-    static public Map<String, String> getWebSocketHeaders() {
-        Map<String, String> httpHeaders = new HashMap<String, String>();
-        httpHeaders.put("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0");
+    static public LinkedHashMap<String, String> getWebSocketHeaders() {
+        LinkedHashMap<String, String> httpHeaders = new LinkedHashMap<String, String>();
+        httpHeaders.put("User-Agent", DeviceForger.requireRandomDevice().getUserAgent());
         httpHeaders.put("Accept", "*/*");
-        httpHeaders.put("Accept-Language", "en-US,en;q=0.5");
+        httpHeaders.put("Accept-Language", "zh-CN,zh;q=0.9");
         httpHeaders.put("Accept-Encoding", "gzip, deflate, br");
         httpHeaders.put("Sec-WebSocket-Version", "13");
         httpHeaders.put("Origin", "https://www.piesocket.com");
         httpHeaders.put("Sec-WebSocket-Extensions", "permessage-deflate");
         httpHeaders.put("Sec-WebSocket-Key", "9cwI/6tCIyNBM4XSsi3jMA==");
-        httpHeaders.put("DNT", "1");
         httpHeaders.put("Connection", "keep-alive, Upgrade");
         httpHeaders.put("Sec-Fetch-Dest", "websocket");
         httpHeaders.put("Sec-Fetch-Mode", "websocket");
@@ -118,35 +294,16 @@ public class BilibiliService extends StreamingService {
         return httpHeaders;
     }
 
-    static public Map<String, List<String>> getUpToDateHeaders() throws ParsingException, IOException, ReCaptchaException, JsonParserException {
-        JsonObject data = JsonParser.object().from(getDownloader().get(FETCH_COOKIE_URL).responseBody()).getObject("data");
-        String cookie = "buvid3="+data.getString("b_3") + ";buvid4="+ data.getString("b_4") + ";";
-        final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("Cookie", Collections.singletonList(cookie));
-        headers.put("User-Agent", Collections.singletonList(DeviceForger.requireRandomDevice().getUserAgent()));
-        headers.put("Accept-Language", Collections.singletonList("en,zh-CN;q=0.9,zh;q=0.8"));
-        headers.put("Referer", Collections.singletonList("https://www.bilibili.com"));
-        return headers;
-    }
-
-    static public Map<String, List<String>> getDownloadHeaders(){
-        final Map<String, List<String>> headers = new HashMap<>();
-        headers.put("User-Agent", Collections.singletonList(DeviceForger.requireRandomDevice().getUserAgent()));
-        headers.put("Accept-Language", Collections.singletonList("en,zh-CN;q=0.9,zh;q=0.8"));
-        headers.put("Referer", Collections.singletonList("https://www.bilibili.com"));
-        return headers;
-    }
-
-    static public Map<String, List<String>> getSponsorBlockHeaders(){
-        final Map<String, List<String>> headers = new HashMap<>();
+    static public LinkedHashMap<String, List<String>> getSponsorBlockHeaders(){
+        final LinkedHashMap<String, List<String>> headers = new LinkedHashMap<>();
         headers.put("Origin", Collections.singletonList("PipePipe"));
         return headers;
     }
 
-    static public Map<String, List<String>> getLoggedHeadersOrNull(String condition){
-        Map<String, List<String>> headers = getHeaders();
-        if(ServiceList.BiliBili.hasTokens() && ServiceList.BiliBili.getCookieFunctions() != null
-                && ServiceList.BiliBili.getCookieFunctions().contains(condition)){
+    static public LinkedHashMap<String, List<String>> getLoggedHeadersOrNull(String originalUrl, String condition) throws MalformedURLException {
+        if (ServiceList.BiliBili.hasTokens() && ServiceList.BiliBili.getCookieFunctions() != null
+                && ServiceList.BiliBili.getCookieFunctions().contains(condition)) {
+            LinkedHashMap<String, List<String>> headers = getUserAgentHeaders(originalUrl);
             headers.put("Cookie", Collections.singletonList(ServiceList.BiliBili.getTokens()));
             return headers;
         }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliWebSocketClient.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/BilibiliWebSocketClient.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.Executors;
@@ -38,7 +39,7 @@ public class BilibiliWebSocketClient {
             this.setConnectionLostTimeout(0);
         }
         public byte[] encode(String data, int op) throws IOException {
-            byte[] dataByte = data.getBytes();
+            byte[] dataByte = data.getBytes(StandardCharsets.UTF_8);
             int length = dataByte.length;
             byte[] result = {0, 0, 0, 0, 0, 16, 0, 1, 0, 0, 0, (byte) op, 0, 0, 0, 1};
             for(int i = 0; i < 4; i++){

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/DeviceForger.java
@@ -1,7 +1,7 @@
 package org.schabi.newpipe.extractor.services.bilibili;
 
 import java.util.Locale;
-import java.util.Random;
+import java.util.SplittableRandom;
 
 import javax.annotation.Nonnull;
 
@@ -15,6 +15,9 @@ public class DeviceForger {
 
         private String webGLRendererInfo;
         private String webGLRendererInfoBase64;
+
+        private int innerWidth;
+        private int innerHeight;
 
         public String getUserAgent() {
             return userAgent;
@@ -41,6 +44,16 @@ public class DeviceForger {
             return webGLRendererInfo;
         }
 
+        public Device(String userAgent, String webGlVersion, String webGLRendererInfo, int innerWidth, int innerHeight) {
+            this.userAgent = userAgent;
+            this.webGlVersion = webGlVersion;
+            this.webGlVersionBase64 = utils.encodeToBase64SubString(webGlVersion);
+            this.webGLRendererInfo = webGLRendererInfo;
+            this.webGLRendererInfoBase64 = utils.encodeToBase64SubString(webGLRendererInfo);
+            this.innerWidth = innerWidth;
+            this.innerHeight = innerHeight;
+        }
+
         public String getWebGLRendererInfoBase64() {
             return webGLRendererInfoBase64;
         }
@@ -50,12 +63,20 @@ public class DeviceForger {
             this.webGLRendererInfoBase64 = utils.encodeToBase64SubString(webGLRendererInfo);
         }
 
-        public Device(String userAgent, String webGlVersion, String webGLRendererInfo) {
-            this.userAgent = userAgent;
-            this.webGlVersion = webGlVersion;
-            this.webGlVersionBase64 = utils.encodeToBase64SubString(webGlVersion);
-            this.webGLRendererInfo = webGLRendererInfo;
-            this.webGLRendererInfoBase64 = utils.encodeToBase64SubString(webGLRendererInfo);
+        public int getInnerWidth() {
+            return innerWidth;
+        }
+
+        void setInnerWidth(int innerWidth) {
+            this.innerWidth = innerWidth;
+        }
+
+        public int getInnerHeight() {
+            return innerHeight;
+        }
+
+        void setInnerHeight(int innerHeight) {
+            this.innerHeight = innerHeight;
         }
 
         public String info() {
@@ -90,14 +111,14 @@ public class DeviceForger {
     final static String ChromiumAngleRendererInfoTemplate = "ANGLE (%s, %s Direct3D11 vs_5_0 ps_5_0, D3D11)Google Inc. (%s)";
 
     static String buildUserAgent(String platform, int version) {
-        return String.format(Locale.US, UserAgentTemplate, platform, version);
+        return String.format(Locale.ROOT, UserAgentTemplate, platform, version);
     }
 
     static String buildChromiumAngleRendererInfo(String vendor, String gpuWithApi) {
-        return String.format(ChromiumAngleRendererInfoTemplate, vendor, gpuWithApi, vendor);
+        return String.format(Locale.ROOT, ChromiumAngleRendererInfoTemplate, vendor, gpuWithApi, vendor);
     }
 
-    static GraphicCard randomCard(Random random) {
+    static GraphicCard randomCard(SplittableRandom random) {
         GraphicCard[] cards = {
                 new GraphicCard("AMD", "AMD Radeon 780M Graphics (0x000015BF)"),
                 new GraphicCard("AMD", "AMD Radeon RX 5700 (0x0000731F)"),
@@ -191,22 +212,22 @@ public class DeviceForger {
                 new GraphicCard("NVIDIA", "NVIDIA GeForce RTX 4090 (0x00002684)"),
                 new GraphicCard("NVIDIA", "NVIDIA GeForce RTX 4090 D (0x00002685)"),
                 new GraphicCard("NVIDIA", "NVIDIA Quadro P2000 (0x00001C30)"),
-                new GraphicCard("Unknown", "Mi Pad 5 Adreno 640 GPU"),
-                new GraphicCard("Unknown", "Qualcomm(R) Adreno(TM) 8cx Gen 3"),
         };
         return cards[random.nextInt(cards.length)];
     }
 
-    static Device forgeDevice(Random random) {
+    static Device forgeDevice(SplittableRandom random) {
         // currently we only forge device with
-        // * Modern Chrome Browse (so User Agent are frozen)
+        // * Modern Chrome Browser (so User Agent are frozen)
         // * Windows 10/11 X64 Operate System
-        int chromiumVersion = (random.nextInt(4)) + 126;
+        int chromiumVersion = (random.nextInt(8)) + 130;
         GraphicCard graphicCard = randomCard(random);
         Device device = new Device(
                 buildUserAgent("Windows NT 10.0; Win64; x64", chromiumVersion),
                 DefaultChromiumWebGlVersion,
-                buildChromiumAngleRendererInfo(graphicCard.getVendor(), graphicCard.getModel())
+                buildChromiumAngleRendererInfo(graphicCard.getVendor(), graphicCard.getModel()),
+                1920 - 60 - random.nextInt(60),
+                1080 - 90 - random.nextInt(60)
         );
         return device;
     }
@@ -222,7 +243,7 @@ public class DeviceForger {
     }
 
     static public void regenerateRandomDevice() {
-        currentDevice = forgeDevice(new Random(System.currentTimeMillis()));
+        currentDevice = forgeDevice(new SplittableRandom());
     }
 
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelTabExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliChannelTabExtractor.java
@@ -1,5 +1,6 @@
 package org.schabi.newpipe.extractor.services.bilibili.extractors;
 
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getDefaultCookies;
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getHeaders;
 import static org.schabi.newpipe.extractor.services.bilibili.utils.getNextPageFromCurrentUrl;
 
@@ -37,7 +38,7 @@ public class BilibiliChannelTabExtractor extends ChannelTabExtractor {
             extractor.onFetchPage(getDownloader());
             return (InfoItemsPage<InfoItem>) (InfoItemsPage<?>) extractor.getInitialPage(); // I don't want to but to support YouTube I have to...
         }
-        return getPage(new Page(getLinkHandler().getUrl()));
+        return getPage(new Page(getLinkHandler().getUrl(), getDefaultCookies()));
     }
 
     @Override
@@ -47,7 +48,7 @@ public class BilibiliChannelTabExtractor extends ChannelTabExtractor {
             return (InfoItemsPage<InfoItem>) (InfoItemsPage<?>) extractor.getPage(page); // I don't want to but to support YouTube I have to...
         }
         final MultiInfoItemsCollector collector = new MultiInfoItemsCollector(getServiceId());
-        String response = getDownloader().get(page.getUrl(), getHeaders()).responseBody();
+        String response = getDownloader().get(page.getUrl(), getHeaders(getOriginalUrl())).responseBody();
         try {
             JsonObject data = JsonParser.object().from(response).getObject("data");
             JsonArray seasons_list = data.getObject("items_lists").getArray("seasons_list");
@@ -77,6 +78,6 @@ public class BilibiliChannelTabExtractor extends ChannelTabExtractor {
         if (ServiceList.BiliBili.getFilterTypes().contains("channels")) {
             collector.applyBlocking(ServiceList.BiliBili.getStreamKeywordFilter(), ServiceList.BiliBili.getStreamChannelFilter(), ServiceList.BiliBili.isFilterShorts());
         }
-        return new InfoItemsPage<>(collector, new Page(getNextPageFromCurrentUrl(page.getUrl(), "page_num", 1)));
+        return new InfoItemsPage<>(collector, new Page(getNextPageFromCurrentUrl(page.getUrl(), "page_num", 1), getDefaultCookies()));
     }
 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliCommentsInfoItemExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliCommentsInfoItemExtractor.java
@@ -12,6 +12,7 @@ import org.schabi.newpipe.extractor.services.bilibili.linkHandler.BilibiliChanne
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -22,6 +23,7 @@ import java.util.Date;
 import java.util.stream.Collectors;
 
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.COMMENT_REPLIES_URL;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getDefaultCookies;
 
 public class BilibiliCommentsInfoItemExtractor implements CommentsInfoItemExtractor {
     public JsonObject data;
@@ -97,7 +99,11 @@ public class BilibiliCommentsInfoItemExtractor implements CommentsInfoItemExtrac
         if (data.getLong("root") == data.getLong("parent") && data.getLong("root") == data.getLong("rpid")) {
             return null;
         }
-        return new Page(getUrl());
+        try {
+            return new Page(getUrl(), getDefaultCookies());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliFeedExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliFeedExtractor.java
@@ -82,21 +82,21 @@ public class BilibiliFeedExtractor extends KioskExtractor<StreamInfoItem> {
             case "Recommended Videos":
             default:
                 try {
-                    response = JsonParser.object().from(getDownloader().get("https://api.bilibili.com/x/web-interface/index/top/rcmd?fresh_type=3", getHeaders()).responseBody());
+                    response = JsonParser.object().from(getDownloader().get("https://api.bilibili.com/x/web-interface/index/top/rcmd?fresh_type=3", getHeaders(getOriginalUrl())).responseBody());
                 } catch (JsonParserException e) {
                     e.printStackTrace();
                 }
                 break;
             case "Top 100":
                 try {
-                    response = JsonParser.object().from(downloader.get(getUrl(), getHeaders()).responseBody());
+                    response = JsonParser.object().from(downloader.get(getUrl(), getHeaders(getOriginalUrl())).responseBody());
                 } catch (JsonParserException e) {
                     throw new RuntimeException(e);
                 }
                 break;
             case "Recommended Lives":
                 try {
-                    response = JsonParser.object().from(downloader.get(getUrl() + "&page=1", getHeaders()).responseBody());
+                    response = JsonParser.object().from(downloader.get(getUrl() + "&page=1", getHeaders(getOriginalUrl())).responseBody());
                 } catch (JsonParserException e) {
                     throw new RuntimeException(e);
                 }

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliPlaylistExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliPlaylistExtractor.java
@@ -39,7 +39,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
     @Override
     public void onFetchPage(@Nonnull Downloader downloader) throws IOException, ExtractionException {
         try {
-            data = JsonParser.object().from(getDownloader().get(getLinkHandler().getUrl(), getHeaders()).responseBody());
+            data = JsonParser.object().from(getDownloader().get(getLinkHandler().getUrl(), getHeaders(getOriginalUrl())).responseBody());
             if (getLinkHandler().getUrl().contains(GET_SEASON_ARCHIVES_ARCHIVE_BASE_URL)) {
                 type = "seasons_archives";
             } else if (getLinkHandler().getUrl().contains(GET_SERIES_BASE_URL)) {
@@ -49,7 +49,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
                 return;
             }
             data = data.getObject("data");
-            String userResponse = getDownloader().get(QUERY_USER_INFO_URL + utils.getMidFromRecordApiUrl(getLinkHandler().getUrl()), getHeaders()).responseBody();
+            String userResponse = getDownloader().get(QUERY_USER_INFO_URL + utils.getMidFromRecordApiUrl(getLinkHandler().getUrl()), getHeaders(getOriginalUrl())).responseBody();
             userData = JsonParser.object().from(userResponse);
         } catch (JsonParserException e) {
             throw new RuntimeException(e);
@@ -77,7 +77,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
             }
             return new InfoItemsPage<>(collector, null);
         }
-        return getPage(new Page(getUrl() + "&username=" + getUploaderName()));
+        return getPage(new Page(getUrl() + "&username=" + getUploaderName(), getDefaultCookies()));
     }
 
     @Override
@@ -86,7 +86,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
         type = getLinkHandler().getUrl().contains("seasons_archives") ? "seasons_archives" : "archives";
         try {
             if (!(page.getUrl().contains("pn=1") || page.getUrl().contains("page_num=1"))) {
-                data = JsonParser.object().from(getDownloader().get(page.getUrl(), getHeaders()).responseBody()).getObject("data");
+                data = JsonParser.object().from(getDownloader().get(page.getUrl(), getHeaders(getOriginalUrl())).responseBody()).getObject("data");
             }
         } catch (JsonParserException e) {
             throw new RuntimeException(e);
@@ -99,7 +99,7 @@ public class BilibiliPlaylistExtractor extends PlaylistExtractor {
         for (int i = 0; i < results.size(); i++) {
             collector.commit(new BilibiliChannelInfoItemWebAPIExtractor(results.getObject(i), page.getUrl().split("username=")[1], null));
         }
-        return new InfoItemsPage<>(collector, new Page(utils.getNextPageFromCurrentUrl(page.getUrl(), type.equals("seasons_archives") ? "page_num" : "pn", 1)));
+        return new InfoItemsPage<>(collector, new Page(utils.getNextPageFromCurrentUrl(page.getUrl(), type.equals("seasons_archives") ? "page_num" : "pn", 1), getDefaultCookies()));
     }
 
     @Override

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliSearchExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliSearchExtractor.java
@@ -14,11 +14,11 @@ import org.schabi.newpipe.extractor.*;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.exceptions.ExtractionException;
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
-import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandler;
 import org.schabi.newpipe.extractor.search.SearchExtractor;
 
-import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getUpToDateHeaders;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getDefaultCookies;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getHeaders;
 
 public class BilibiliSearchExtractor extends SearchExtractor{
 
@@ -50,7 +50,7 @@ public class BilibiliSearchExtractor extends SearchExtractor{
         }
         int currentPage = 1;
         String nextPage = getUrl().replace(String.format("page=%s", 1), String.format("page=%s", String.valueOf(currentPage + 1)));
-        return new InfoItemsPage<>(getCommittedCollector(), new Page(nextPage));
+        return new InfoItemsPage<>(getCommittedCollector(), new Page(nextPage, getDefaultCookies()));
     }
 
     private MultiInfoItemsCollector getCommittedCollector(){
@@ -82,7 +82,7 @@ public class BilibiliSearchExtractor extends SearchExtractor{
     @Override
     public InfoItemsPage<InfoItem> getPage(Page page) throws IOException, ExtractionException {
         try {
-            final String html = getDownloader().get(page.getUrl(), getUpToDateHeaders()).responseBody();
+            final String html = getDownloader().get(page.getUrl(), getHeaders(getOriginalUrl())).responseBody();
             searchCollection = JsonParser.object().from(html);
         } catch (JsonParserException e) {
             e.printStackTrace();
@@ -95,14 +95,14 @@ public class BilibiliSearchExtractor extends SearchExtractor{
         String currentPageString = page.getUrl().split("page=")[page.getUrl().split("page=").length-1];
         int currentPage = Integer.parseInt(currentPageString);
         String nextPage = page.getUrl().replace(String.format("page=%s", currentPageString), String.format("page=%s", String.valueOf(currentPage + 1)));
-        return new InfoItemsPage<>(getCommittedCollector(), new Page(nextPage));
+        return new InfoItemsPage<>(getCommittedCollector(), new Page(nextPage, getDefaultCookies()));
     }
 
     @Override
     public void onFetchPage(Downloader downloader) throws IOException, ExtractionException {
         try {
             final String response = getDownloader().get(
-                    getLinkHandler().getUrl(), getUpToDateHeaders()).responseBody();
+                    getLinkHandler().getUrl(), getHeaders(getOriginalUrl())).responseBody();
             searchCollection = JsonParser.object().from(response);
         } catch (final JsonParserException e) {
             throw new ExtractionException("could not parse search results.");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliSuggestionExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BilibiliSuggestionExtractor.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.GET_SUGGESTION_URL;
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.WWW_REFERER;
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.getHeaders;
 
 public class BilibiliSuggestionExtractor extends SuggestionExtractor {
@@ -23,7 +24,7 @@ public class BilibiliSuggestionExtractor extends SuggestionExtractor {
 
     @Override
     public List<String> suggestionList(String query) throws IOException, ExtractionException {
-        final String response = NewPipe.getDownloader().get(GET_SUGGESTION_URL + query, getHeaders()).responseBody();
+        final String response = NewPipe.getDownloader().get(GET_SUGGESTION_URL + query, getHeaders(WWW_REFERER)).responseBody();
         List<String> resultList = new ArrayList<>();
         try {
             JsonArray respObject = JsonParser.object().from(response).getObject("result").getArray("tag");

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
@@ -21,7 +21,6 @@ import org.schabi.newpipe.extractor.utils.Utils;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -31,6 +30,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.*;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.bv2av;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.formatParamWithPercentSpace;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.getDmImgParams;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.getWbiResult;
 
 public class BillibiliStreamExtractor extends StreamExtractor {
 
@@ -289,13 +292,13 @@ public class BillibiliStreamExtractor extends StreamExtractor {
                         bvid = responseJson.getString("bvid");
                         response = getDownloader().get("https://api.bilibili.com/x/player/playurl" + "?cid="
                                 + responseJson.getLong("cid") + "&bvid=" + bvid
-                                + "&fnval=2000&qn=120&fourk=1&try_look=1", getHeaders()).responseBody();
+                                + "&fnval=4048&qn=120&fourk=1&try_look=1", getHeaders(getOriginalUrl())).responseBody();
                         playData = JsonParser.object().from(response);
                         dataObject = playData.getObject("data").getObject("dash");
                         buildStreams();
                         nextTimestamp = timestamp + dataObject.getLong("duration") * 1000;
                     case 1:
-                        response = getDownloader().get("https://api.live.bilibili.com/room/v1/Room/playUrl?qn=10000&platform=web&cid=" + getId(), getHeaders()).responseBody();
+                        response = getDownloader().get("https://api.live.bilibili.com/room/v1/Room/playUrl?qn=10000&platform=web&cid=" + getId(), getHeaders(getOriginalUrl())).responseBody();
                         liveUrl = JsonParser.object().from(response).getObject("data").getArray("durl").getObject(0).getString("url");
                 }
             } catch (JsonParserException e) {
@@ -312,7 +315,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             String response;
             try {
                 response = downloader.get("https://api.bilibili.com/pgc/view/web/season?"
-                        + (type == 0 ? "season_id=" : "ep_id=") + getId().substring(2), getHeaders()).responseBody();
+                        + (type == 0 ? "season_id=" : "ep_id=") + getId().substring(2), getHeaders(getOriginalUrl())).responseBody();
             } catch (Exception e) {
                 throw new ContentNotAvailableException("Unknown reason");
             }
@@ -348,7 +351,9 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             String url = getLinkHandler().getOriginalUrl();
             bvid = utils.getPureBV(getId());
             url = utils.getUrl(url, bvid);
-            String response = downloader.get(url, getLoggedHeadersOrNull("ai_subtitle")).responseBody();
+            String response = downloader.get(url,
+                    getLoggedHeadersOrNull(getOriginalUrl(), "ai_subtitle") != null ? getLoggedHeadersOrNull(getOriginalUrl(), "ai_subtitle") : getHeaders(getOriginalUrl())
+            ).responseBody();
             try {
                 watch = JsonParser.object().from(response).getObject("data");
             } catch (JsonParserException e) {
@@ -368,7 +373,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
         }
 
         // step 1.5: other requests, should start early to improve speed
-        tagCall = downloader.getAsync(FETCH_TAGS_URL + utils.getPureBV(getId()), getHeaders(), response1 -> {
+        tagCall = downloader.getAsync(FETCH_TAGS_URL + utils.getPureBV(getId()), getHeaders(getOriginalUrl()), response1 -> {
             try {
                 tagData = JsonParser.object().from(response1.responseBody()).getArray("data");
             } catch (JsonParserException e) {
@@ -376,43 +381,66 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             }
         });
         if (isPremiumContent != 1) {
-            partitionCall = downloader.getAsync(GET_PARTITION_URL + bvid, getHeaders(), response1 -> {
+            partitionCall = downloader.getAsync(GET_PARTITION_URL + bvid, getHeaders(getOriginalUrl()), response1 -> {
                 try {
                     partitionData = JsonParser.object().from(response1.responseBody()).getArray("data");
                 } catch (JsonParserException e) {
                     e.printStackTrace();
                 }
             });
-            relatedCall = downloader.getAsync(GET_RELATED_URL + bvid, getHeaders(), response1 -> {
+            relatedCall = downloader.getAsync(GET_RELATED_URL + bvid, getHeaders(getOriginalUrl()), response1 -> {
                 try {
                     relatedData = JsonParser.object().from(response1.responseBody()).getArray("data");
                 } catch (JsonParserException e) {
                     e.printStackTrace();
                 }
             });
-            if (getLoggedHeadersOrNull("ai_subtitle") != null) {
-                subtitleCall = downloader.getAsync(GET_SUBTITLE_META_URL + "?cid=" + cid + "&bvid=" + bvid, getLoggedHeadersOrNull("ai_subtitle"), response1 -> {
-                    try {
-                        subtitleData = JsonParser.object().from(response1.responseBody()).getObject("data").getObject("subtitle").getArray("subtitles");
-                    } catch (JsonParserException e) {
-                        e.printStackTrace();
-                    }
-                });
+            if (getLoggedHeadersOrNull(getOriginalUrl(), "ai_subtitle") != null) {
+                LinkedHashMap<String, String> params = new LinkedHashMap<>();
+                params.put("aid", String.valueOf(utils.bv2av(bvid)));
+                params.put("cid", String.valueOf(cid));
+                params.put("isGaiaAvoided", "false");
+                params.put("web_location", "1315873");
+                params.putAll(getDmImgParams());
+                subtitleCall = downloader.getAsync(
+                        getWbiResult(GET_SUBTITLE_META_URL, params),
+                        getLoggedHeadersOrNull(getOriginalUrl(), "ai_subtitle"), response1 -> {
+                            try {
+                                subtitleData = JsonParser.object().from(response1.responseBody()).getObject("data").getObject("subtitle").getArray("subtitles");
+                            } catch (JsonParserException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                );
             }
         }
 
 
         // step 2: fetch stream data
         String baseUrl = isPremiumContent != 1 ? FREE_VIDEO_BASE_URL : PAID_VIDEO_BASE_URL;
-        String params = "?cid=" + cid + "&bvid=" + bvid + "&fnval=2000&qn=120&fourk=1";
-        Map<String, List<String>> headers = getHeaders();
+        LinkedHashMap<String, String> params = new LinkedHashMap<>();
+        params.put("avid", String.valueOf(bv2av(bvid)));
+        params.put("bvid", bvid);
+        params.put("cid", String.valueOf(cid));
+
+        params.put("qn", "120");
+        params.put("fnver", "0");
+        params.put("fnval", "4048");
+        params.put("fourk", "1");
+
+        Map<String, List<String>> headers = getHeaders(getOriginalUrl());
         if (ServiceList.BiliBili.hasTokens() && ServiceList.BiliBili.getCookieFunctions().contains("high_res")) {
             headers.put("Cookie", Collections.singletonList(ServiceList.BiliBili.getTokens()));
         } else {
             // https://codeberg.org/NullPointerException/PipePipe/issues/42
-            params += "&try_look=1";
+            params.put("try_look", "1");
         }
-        String response = getDownloader().get(baseUrl + params, headers).responseBody();
+
+        params.put("web_location", "1315873");
+
+        params.putAll(getDmImgParams());
+
+        String response = getDownloader().get(getWbiResult(baseUrl, params), headers).responseBody();
         try {
             playData = JsonParser.object().from(response);
             switch (playData.getInt("code")) {
@@ -555,7 +583,18 @@ public class BillibiliStreamExtractor extends StreamExtractor {
                 collector.commit(new BilibiliRelatedInfoItemExtractor(relatedData.getObject(i)));
                 if (i == 0 && partitions > 1) {
                     collector.commit(new BilibiliPlaylistInfoItemExtractor(watch.getString("title"),
-                            GET_PARTITION_URL + bvid + "&name=" + watch.getString("title") + "&thumbnail=" + URLEncoder.encode(getThumbnailUrl(), "UTF-8") + "&uploaderName=" + getUploaderName() + "&uploaderAvatar=" + URLEncoder.encode(getUploaderAvatarUrl(), "UTF-8") + "&uploaderUrl=" + URLEncoder.encode(getUploaderUrl(), "UTF-8"),
+                            GET_PARTITION_URL
+                                    + bvid
+                                    + "&name="
+                                    + watch.getString("title")
+                                    + "&thumbnail="
+                                    + formatParamWithPercentSpace(getThumbnailUrl())
+                                    + "&uploaderName="
+                                    + getUploaderName()
+                                    + "&uploaderAvatar="
+                                    + formatParamWithPercentSpace(getUploaderAvatarUrl())
+                                    + "&uploaderUrl="
+                                    + formatParamWithPercentSpace(getUploaderUrl()),
                             getThumbnailUrl(), getUploaderName(), partitions));
                 }
             }
@@ -563,7 +602,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
                 collector.applyBlocking(ServiceList.BiliBili.getStreamKeywordFilter(), ServiceList.BiliBili.getStreamChannelFilter(), ServiceList.BiliBili.isFilterShorts());
             }
             return collector;
-        } catch (ParsingException | IOException e) {
+        } catch (ParsingException e) {
             e.printStackTrace();
         }
         return collector;
@@ -593,7 +632,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
     @Nonnull
     @Override
     public List<SubtitlesStream> getSubtitlesDefault() throws IOException, ExtractionException {
-        if (getLoggedHeadersOrNull("ai_subtitle") == null || getStreamType().equals(StreamType.LIVE_STREAM)
+        if (getLoggedHeadersOrNull(getOriginalUrl(), "ai_subtitle") == null || getStreamType().equals(StreamType.LIVE_STREAM)
                 || isPremiumContent == 1) {
             return new ArrayList<>();
         }
@@ -604,7 +643,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             String bccResult = getDownloader()
                     .get("https:" + subtitlesStream
                             .getString("subtitle_url")
-                            .replace("http:", "https:"), getHeaders()).responseBody();
+                            .replace("http:", "https:"), getHeaders(getOriginalUrl())).responseBody();
             try {
                 subtitlesToReturn.add(new SubtitlesStream.Builder()
                         .setContent(utils.bcc2srt(JsonParser.object().from(bccResult)), false)
@@ -688,7 +727,7 @@ public class BillibiliStreamExtractor extends StreamExtractor {
         try {
             String videoshotUrl = VIDEOSHOT_API_URL + bvid;
             
-            String response = getDownloader().get(videoshotUrl, getHeaders()).responseBody();
+            String response = getDownloader().get(videoshotUrl, getHeaders(getOriginalUrl())).responseBody();
             JsonObject responseJson = JsonParser.object().from(response);
             
             if (responseJson.getInt("code") != 0) {

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliCommentsLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliCommentsLinkHandlerFactory.java
@@ -6,7 +6,7 @@ import org.schabi.newpipe.extractor.search.filter.FilterItem;
 import org.schabi.newpipe.extractor.services.bilibili.WatchDataCache;
 import org.schabi.newpipe.extractor.services.bilibili.utils;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.FETCH_COMMENTS_URL;
@@ -59,11 +59,11 @@ public class BilibiliCommentsLinkHandlerFactory extends ListLinkHandlerFactory {
             return "https://api.bilibili.com/x/v2/reply/reply?type=1&ps=20&oid=" + id + "&pn=1";
         }
         String finalId = id;
-        return utils.getWbiResult(FETCH_COMMENTS_URL, new HashMap<String, String>(){{
+        return utils.getWbiResult(FETCH_COMMENTS_URL, new LinkedHashMap<String, String>() {{
             put("oid", finalId);
             put("type", "1");
             put("mode", "3");
-            put("pagination_str","{\"offset\":\"\"}");
+            put("pagination_str", "{\"offset\":\"\"}");
             put("plat", "1");
             put("web_location", "1315875");
         }});

--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliSearchQueryHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/linkHandler/BilibiliSearchQueryHandlerFactory.java
@@ -2,7 +2,7 @@
 
 package org.schabi.newpipe.extractor.services.bilibili.linkHandler;
 
-import static org.schabi.newpipe.extractor.utils.Utils.UTF_8;
+import static org.schabi.newpipe.extractor.services.bilibili.utils.formatParamWithPercentSpace;
 
 import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.linkhandler.SearchQueryHandlerFactory;
@@ -10,8 +10,6 @@ import org.schabi.newpipe.extractor.search.filter.Filter;
 import org.schabi.newpipe.extractor.search.filter.FilterItem;
 import org.schabi.newpipe.extractor.services.bilibili.search.filter.BilibiliFilters;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.List;
 
 public class BilibiliSearchQueryHandlerFactory extends SearchQueryHandlerFactory {
@@ -31,11 +29,7 @@ public class BilibiliSearchQueryHandlerFactory extends SearchQueryHandlerFactory
 
         final String filterQuery = searchFilters.evaluateSelectedContentFilters();
 
-        try {
-            return SEARCH_URL + filterQuery + "&keyword=" + URLEncoder.encode(query, UTF_8) + "&page=1";
-        } catch (final UnsupportedEncodingException e) {
-            throw new ParsingException("query \"" + query + "\" could not be encoded", e);
-        }
+        return SEARCH_URL + filterQuery + "&keyword=" + formatParamWithPercentSpace(query) + "&page=1";
     }
 
     @Override


### PR DESCRIPTION
Implements several new mechanisms to bypass Bilibili's updated and stricter API risk controls.

- Adds calculation for new risk control cookies and headers, including `b_nut`, `b_lsid`, `_uuid`, `bili_ticket`, and `buvid_fp`.
- Generates `dm_img_inter` device fingerprinting parameter based on forged screen data to appear as a more legitimate client.
- Unifies all API request headers into a central method. This ensures headers and cookies are consistently ordered to match browser behavior, using LinkedHashMap.
- Implements caching for the WBI mixin key and user `w_webid` to reduce redundant network requests and improve performance.