### PR TITLE
fix(PeerTube): replace unsupported parameter for local search

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/peertube/linkHandler/PeertubeTrendingLinkHandlerFactory.java
@@ -28,7 +28,7 @@ public final class PeertubeTrendingLinkHandlerFactory extends ListLinkHandlerFac
         map.put(KIOSK_TRENDING, "%s/api/v1/videos?sort=-trending");
         map.put(KIOSK_MOST_LIKED, "%s/api/v1/videos?sort=-likes");
         map.put(KIOSK_RECENT, "%s/api/v1/videos?sort=-publishedAt");
-        map.put(KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&filter=local");
+        map.put(KIOSK_LOCAL, "%s/api/v1/videos?sort=-publishedAt&isLocal=true");
         KIOSK_MAP = Collections.unmodifiableMap(map);
 
         final Map<String, String> reverseMap = new HashMap<>();


### PR DESCRIPTION
According to the issue: https://github.com/InfinityLoop1308/PipePipe/issues/1264

The root cause is that the API endpoint has changed the parameter for getting the local videos.

Old: https://framatube.org/api/v1/videos?sort=-publishedAt&filter=local
<img width="1243" height="264" alt="image" src="https://github.com/user-attachments/assets/357522b8-9762-488a-bcb8-63df42bdb5bd" />

New: https://framatube.org/api/v1/videos?sort=-publishedAt&isLocal=true
<img width="1270" height="798" alt="image" src="https://github.com/user-attachments/assets/23fc6db1-e409-4c7b-9f72-0e9311360ea9" />


# Build verification
Old:
<img width="539" height="1212" alt="image" src="https://github.com/user-attachments/assets/71564333-c383-4e66-a341-77435f973a96" />

New: 
<img width="541" height="1205" alt="image" src="https://github.com/user-attachments/assets/0e73433a-b2d4-45fe-9ace-92ed13ad89df" />

