### PR TITLE
fix: correct Bilibili like count

### DIFF
--- a/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
+++ b/extractor/src/main/java/org/schabi/newpipe/extractor/services/bilibili/extractors/BillibiliStreamExtractor.java
@@ -539,9 +539,9 @@ public class BillibiliStreamExtractor extends StreamExtractor {
             return -1;
         }
         if (isPremiumContent == 1) {
-            return premiumData.getObject("stat").getLong("coins");
+            return premiumData.getObject("stat").getLong("likes");
         }
-        return watch.getObject("stat").getLong("coin");
+        return watch.getObject("stat").getLong("like");
     }
 
     @Nonnull


### PR DESCRIPTION
The `getLikeCount()` method was incorrectly returning the coin count instead of the like count. This has been fixed to use the correct field from the API response.